### PR TITLE
Changed two references from addon to DataStore

### DIFF
--- a/DataStore_Mails/DataStore_Mails.lua
+++ b/DataStore_Mails/DataStore_Mails.lua
@@ -364,7 +364,7 @@ local commCallbacks = {
 			guildMailRecipientKey = nil
 		end,
 	[MSG_SENDMAIL_ATTACHMENT] = function(sender, icon, link, count)
-			local id = addon:GetCharacterID(guildMailRecipientKey)
+			local id = DataStore:GetCharacterID(guildMailRecipientKey)
 			local recipientTable = allCharacters[id]
 			
 			if recipientTable then
@@ -372,7 +372,7 @@ local commCallbacks = {
 			end
 		end,
 	[MSG_SENDMAIL_BODY] = function(sender, subject, body, money)
-			local id = addon:GetCharacterID(guildMailRecipientKey)
+			local id = DataStore:GetCharacterID(guildMailRecipientKey)
 			local recipientTable = allCharacters[id]
 
 			if recipientTable then


### PR DESCRIPTION
When receiving mail from a guild member, the communication callbacks referenced addon instead of DataStore. Changing to DataStore resolves the issue.